### PR TITLE
feat: improve Wizard testability with aria-label and data-stepindex

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -62,6 +62,7 @@ export const Button: React.FC<ButtonProps> = ({
 
 export interface IconButtonProps {
   iconName: IconName;
+  label?: string;
   size?: number;
   disabled?: boolean;
   onClick: (evt: React.MouseEvent<HTMLButtonElement>) => void;
@@ -69,6 +70,7 @@ export interface IconButtonProps {
 
 export const IconButton: React.FC<IconButtonProps> = ({
   iconName,
+  label,
   size = 36,
   disabled = false,
   onClick,
@@ -81,7 +83,7 @@ export const IconButton: React.FC<IconButtonProps> = ({
     "hover:bg-gray-50": true,
   });
   return (
-    <button className={classes} onClick={onClick} disabled={disabled}>
+    <button className={classes} onClick={onClick} disabled={disabled} aria-label={label ?? iconName}>
       <Icon iconName={iconName} size={size} />
     </button>
   );

--- a/src/components/Wizard/Wizard.tsx
+++ b/src/components/Wizard/Wizard.tsx
@@ -68,10 +68,10 @@ const WizardButtonControl: React.FC<WizardButtonControlProps> = ({
     prevNextButtonPartial = (
       <>
         {showPreviousButton && (
-          <IconButton iconName="ArrowLeft" onClick={onBack} />
+          <IconButton iconName="ArrowLeft" label="Back" onClick={onBack} />
         )}
         {showNextButton && (
-          <IconButton iconName="ArrowRight" onClick={onNext} />
+          <IconButton iconName="ArrowRight" label="Next" onClick={onNext} />
         )}
       </>
     );
@@ -152,8 +152,8 @@ export const Wizard: React.FC<WizardProps> = ({
       style={styles}
     >
       <WizardContext.Provider value={{ setStepReady, getStepReady }}>
-        <div className="w-full h-11/12 flex-grow ">{children[currentStep]}</div>
-        <div className="bottom-1 w-full">
+        <div className="w-full h-11/12 flex-grow " data-stepindex={currentStep}>{children[currentStep]}</div>
+        <div className="bottom-1 w-full min-h-10">
           <WizardButtonControl
             showPreviousButton={currentStep !== 0}
             showNextButton={


### PR DESCRIPTION
## Summary
- Adds optional `label` prop to `IconButton` rendered as `aria-label` (falls back to `iconName`), enabling Playwright role-based selectors
- Passes `label="Back"` / `label="Next"` to Wizard's icon navigation buttons
- Adds `data-stepindex={currentStep}` to the Wizard content wrapper div for stable step assertions

## Test plan
- [x] In Storybook, inspect Wizard with `useIconButtons` — Back/Next buttons should have `aria-label="Back"` / `aria-label="Next"`
- [x] Click through Wizard steps and confirm `data-stepindex` updates on the content wrapper
- [ ] In Storybook A11y panel, confirm no "button has no accessible name" violations on icon buttons

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)